### PR TITLE
Fix : AWS 용량 부족으로 인한 build명령어 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "GENERATE_SOURCEMAP=false react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
t2.micro 의 RAM 가용량이 너무 적어서 명령어 수정을 통해 해결