### PR TITLE
Feat : 여행지 중복 선택 및 삭제 기능 추가

### DIFF
--- a/src/components/TravelSchedule.tsx
+++ b/src/components/TravelSchedule.tsx
@@ -4,6 +4,10 @@ import AvatarInfo from "./ui/AvatarInfo";
 import PageNation from "./ui/PageNation";
 import SchedulePost from "./SchedulePost";
 
+import Posts from "./Posts";
+import { useUser } from "../hooks/useUser";
+import { useState } from "react";
+
 export default function TravelSchedule() {
   const imsiPostNubmer = [1, 1, 1, 1, 1];
   const dummySchedulePost = {
@@ -12,6 +16,17 @@ export default function TravelSchedule() {
     date: 5,
     title: "임시 제목",
   };
+  const { user } = useUser();
+  // console.log();
+  const [hoverState, setHoverState] = useState<"none" | "in" | "out">("none");
+
+  const link_record = user ? "/write-record" : "/login";
+  const link_schedule = user ? "/write-schedule" : "/login";
+
+  const newClass = `h-12 mb-1 mx-auto aspect-square shadow-lg leading-none items-center justify-center text-white bg-black/50 rounded-full ${
+    hoverState === "in" ? "flex" : "hidden"
+  }`;
+
   return (
     <div className="flex flex-col w-screen">
       <div>
@@ -20,9 +35,25 @@ export default function TravelSchedule() {
         })}
       </div>
       <PageNation maxPage={12} showPage={5} />
-      <Link to="/write-schedule" className="">
-        일정 작성하기
-      </Link>
+      <div
+        className="fixed right-5 bottom-5"
+        onMouseEnter={() => setHoverState("in")}
+        onMouseLeave={() => setHoverState("out")}
+      >
+        <Link to={link_record} className={newClass}>
+          기록
+        </Link>
+        <Link to={link_schedule} className={newClass}>
+          일정
+        </Link>
+        <div className="h-14 aspect-square shadow-lg leading-none flex items-center justify-center text-white bg-blue-300 rounded-full prevent-drag">
+          <span
+            className={`rotate-on-hover text-6xl xl h-[4.7rem] ${hoverState} pointer-events-none`}
+          >
+            +
+          </span>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/WriteRecord.tsx
+++ b/src/components/WriteRecord.tsx
@@ -22,14 +22,14 @@ export default function WriteRecord() {
   const [isModalOpen, setModal] = useModal();
   const [isOpenDestinationModal, setDestinationModal] = useModal();
   const [isOpenPeriodModal, setPeriodModal] = useModal();
-  const [selectedLocation, setSelectedLocation] = useState("");
+  const [selectedLocation, setSelectedLocation] = useState<string[]>([]);
 
-  const handleLocationSelect = (location: string) => {
+  const handleLocationSelect = (location: string[]) => {
     setSelectedLocation(location);
   };
 
   const resetSelectedLocation = () => {
-    setSelectedLocation("");
+    setSelectedLocation([]);
     setDestinationModal();
   };
 
@@ -129,7 +129,7 @@ export default function WriteRecord() {
               <input
                 className="h-10 border border-black/20 shadow-sm rounded-md text-black p-2 w-full mt-1"
                 placeholder=" 여행 장소를 선택해 주세요"
-                value={selectedLocation}
+                value={selectedLocation.join(", ")}
               />
             }
             modal={

--- a/src/components/WriteSchedule.tsx
+++ b/src/components/WriteSchedule.tsx
@@ -12,7 +12,7 @@ import DestinationSelection from "./DestinationSelection";
 
 export default function WriteSchedule() {
   const [travelName, setTravelName] = useState("");
-  const [testTravelArea, setTestTravelArea] = useState("");
+  const [testTravelArea, setTestTravelArea] = useState<string[]>([]);
   const [travelDetails, setTravelDetails] = useState("");
   const [calendar, setCalendar] = useState(false);
   const [selectedDays, setSelectedDays] = useState<SelectDate>([new Date()]);
@@ -51,7 +51,7 @@ export default function WriteSchedule() {
     e.preventDefault();
     const formData = new FormData();
     formData.append("travelName", travelName);
-    formData.append("travelArea", testTravelArea);
+    formData.append("travelArea", testTravelArea.join(", "));
     formData.append("travelDetails", travelDetails);
 
     try {
@@ -66,8 +66,8 @@ export default function WriteSchedule() {
     }
   };
 
-  const handleTestTravelArea = (location: string) => {
-    setTestTravelArea(location);
+  const handleTestTravelArea = (locations: string[]) => {
+    setTestTravelArea(locations);
   };
 
   const [isOpenDestinationModal, setDestinationModal] = useModal();
@@ -142,7 +142,7 @@ export default function WriteSchedule() {
           />
         </div>
         <div className="flex items-center">
-          <FaLocationDot size={60} color={"#60a4f9"} className="ml-1.5 mr-4" />
+          <FaLocationDot size={60} color={"#60a4f9"} className="ml-1 mr-4" />
           <ModalButton
             button={
               <input
@@ -150,7 +150,7 @@ export default function WriteSchedule() {
                 placeholder="여행 장소를 선택해주세요."
                 readOnly
                 className="h-10 border border-black/20 shadow-sm rounded-md text-black p-2 w-full mt-1"
-                value={testTravelArea ? `${testTravelArea}` : ""}
+                value=""
               />
             }
             modal={
@@ -193,6 +193,21 @@ export default function WriteSchedule() {
             }
           />
         </div>
+        {testTravelArea && (
+          <div className="flex flex-col mt-4">
+            <div className="flex items-center">
+              <FaLocationDot
+                size={20}
+                color={"#60a4f9"}
+                className="ml-1 mr-2"
+              />
+              <h2 className="font-bold mr-2">선택된 여행지</h2>
+            </div>
+            <div className="flex items-center">
+              <p>[ {testTravelArea.join(", ")} ]</p>
+            </div>
+          </div>
+        )}
         {selectedDays.length > 0 && renderTravelScheduleBox()}
         {selectedDays.length > 0 && (
           <div className="flex justify-center">


### PR DESCRIPTION
1. 여행지 중복 선택 수정
- 수정 전 : 1개의 나라에 속한 도시들만 3개까지 중복 선택 가능
- 수정 후 : 대륙-나라 상관 없이 여행지 3개까지 중복 선택 가능

2. 여행지 삭제 기능 추가
- 모달창 안에서 여행지 선택 후 옆에 있는 "X" 버튼을 누르면 여행지 삭제 가능

3. 선택된 여행지 표시 UI 변경
- 수정 전 : "여행 장소를 선택해주세요."에 그대로 표시
- 수정 후 : "여행 장소를 선택해주세요." 아래에 가로로 나열하여 표시